### PR TITLE
Extended to support multiple host names per domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 papakiDynDNS
 ============
 
-Χαρήκατε που το papaki.gr προσφέρει δωρεάν υπηρεσίες DNS Hosting, άλλα βαριέστε να τους περιμένετε να υλοποιήσουν Dynamic DNS; αυτό το project ίσως σας δώσει την λύση.
+Extended the original papakiDynDNS to support multiple host names per domain.
+
+Since papaki.com still does not support auto-updating IP addresses for our domains I found the tool really useful and extended it to fit my needs. I have now set it to run through a bash script on Ubuntu Server 16.04 using a simple command "php papakiDynDNS.php", so that saves me the hassle to have to log in and change each entry separately every time the server's (dynamic) IP changes.
+
+You just need to update the "Setup" section with your server's details:
+
+//Setup
+$config['hosts'] = array('', 'www', 'mail'); //Add all your host names here
+$config['domain'] = 'example.gr';
+$config['new_ip_address'] = file_get_contents('http://icanhazip.com/'); //Update this with the IP of your server if not on it
+$config['papaki_username'] = 'username';
+$config['papaki_password'] = 'password';
+
+Then you can save, exit, and run the script on your server through the command line using the following command:
+"php papakiDynDNS.php"
+
+It could also be further extended to work based on external parameters.
+I hope it makes someone's life easier!

--- a/papakiDynDNS.php
+++ b/papakiDynDNS.php
@@ -16,7 +16,7 @@ include('dom/simple_html_dom.php');
 //Setup
 $config['hosts'] = array('', 'www', 'mail'); //Add all your host names here
 $config['domain'] = 'your_papaki_domain';
-$config['new_ip_address'] = file_get_contents('http://icanhazip.com/'); //Update this with the IP of your server if not on it
+$config['new_ip_address'] = trim(file_get_contents('http://icanhazip.com/')); //Update this with the IP of your server if not on it
 $config['papaki_username'] = 'your_papaki_gr_username';
 $config['papaki_password'] = 'your_papaki_gr_password';
 
@@ -56,6 +56,7 @@ if (DEBUG) print_r("Searching for the needed A record(s).\n");
 $html = new simple_html_dom();
 $html->load($response);
 $records_updated = 0;
+$records_not_updated = 0;
 foreach($html->find('span') as $span)
 {
 	// rpttypes_ctl00 are A records
@@ -73,10 +74,11 @@ foreach($html->find('span') as $span)
 				if ($config['new_ip_address'] == $current_ip[0]->plaintext)
 				{
 					if (DEBUG) print_r("No need to update, IP is the same as the one we are trying to update\n");
-					die();
+					$records_not_updated++;
+					break;
 				}
 
-				if (DEBUG) print_r("The record has to be updated.!\n");
+				if (DEBUG) print_r("The record has to be updated from ". $current_ip[0]->plaintext ." to ". $config['new_ip_address']." .!\n");
 
 				$search_id = 'rpttypes_ctl00_rptRecords_' . $rptRecord . '_lnk_edit';
 				$edit_button = $html->find('a[id=' . $search_id . ']');
@@ -124,7 +126,7 @@ foreach($html->find('span') as $span)
 
 if (DEBUG) print_r("Updated ".$records_updated." out of " . count($config['full_hosts']) . " records\n");
 
-if ($records_updated < count($config['full_hosts']))
+if ($records_updated + $records_not_updated < count($config['full_hosts']))
 {
 	//Not all hosts found - maybe need to create entries
 	if (DEBUG) print_r("WARNING: One or more records were not found. We may have to insert new ones but that has not been implemented yet.\n");

--- a/papakiDynDNS.php
+++ b/papakiDynDNS.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
  * papakiDynDNS.php
  * A script to update a specific dns record at papaki.gr free DNS Hosting service
@@ -13,11 +13,22 @@ define('DEBUG', TRUE);
 
 include('dom/simple_html_dom.php');
 
-$config['host'] = 'your_host_www';
+//Setup
+$config['hosts'] = array('', 'www', 'mail'); //Add all your host names here
 $config['domain'] = 'your_papaki_domain';
-$config['new_ip_address'] = file_get_contents('http://icanhazip.com/');
+$config['new_ip_address'] = file_get_contents('http://icanhazip.com/'); //Update this with the IP of your server if not on it
 $config['papaki_username'] = 'your_papaki_gr_username';
 $config['papaki_password'] = 'your_papaki_gr_password';
+
+//Preparing each host name
+$config['full_hosts'] = array();
+foreach ($config['hosts'] as $host){
+	if ($host == ""){
+		array_push($config['full_hosts'], $config['domain']);
+	}else{
+		array_push($config['full_hosts'], $host . '.' . $config['domain']);
+	}
+}
 
 // Do the login
 $ch = curl_init();
@@ -41,77 +52,82 @@ $response = curl_exec($ch);
 curl_close($ch);
 
 // Search for the A record we need
-if (DEBUG) print_r("Searching for the needed A record.\n");
+if (DEBUG) print_r("Searching for the needed A record(s).\n");
 $html = new simple_html_dom();
 $html->load($response);
-$record_updated = FALSE;
+$records_updated = 0;
 foreach($html->find('span') as $span)
 {
 	// rpttypes_ctl00 are A records
 	if (startsWith($span->id, 'rpttypes_ctl00_rptRecords_ctl') AND endsWith($span->id, '_lbl_name'))
 	{
-		if ($span->plaintext == $config['host'] . '.' . $config['domain'])
+		foreach($config['full_hosts'] as $key => $full_host)
 		{
-			$rptRecord = explode('_', $span->id);
-			$rptRecord = $rptRecord[3];
-
-			$current_ip = $html->find('span[id=rpttypes_ctl00_rptRecords_' . $rptRecord . '_lbl_content]');
-			if (DEBUG) print_r("Record found! " . $span->plaintext . " -> " . $current_ip[0]->plaintext . "\n");
-			if ($config['new_ip_address'] == $current_ip[0]->plaintext)
+			if ($span->plaintext == $full_host)
 			{
-				if (DEBUG) print_r("No need to update, IP is the same as the one we are trying to update\n");
-				die();
+				$rptRecord = explode('_', $span->id);
+				$rptRecord = $rptRecord[3];
+
+				$current_ip = $html->find('span[id=rpttypes_ctl00_rptRecords_' . $rptRecord . '_lbl_content]');
+				if (DEBUG) print_r("Record found! " . $span->plaintext . " -> " . $current_ip[0]->plaintext . "\n");
+				if ($config['new_ip_address'] == $current_ip[0]->plaintext)
+				{
+					if (DEBUG) print_r("No need to update, IP is the same as the one we are trying to update\n");
+					die();
+				}
+
+				if (DEBUG) print_r("The record has to be updated.!\n");
+
+				$search_id = 'rpttypes_ctl00_rptRecords_' . $rptRecord . '_lnk_edit';
+				$edit_button = $html->find('a[id=' . $search_id . ']');
+				$did = $edit_button[0]->did;
+				$mode = $edit_button[0]->mode;
+
+				// Fetch update form, so we can get VIEWSTATE and EVENTVALIDATION
+				if (DEBUG) print_r("Fetching update form.\n");
+				$c = curl_init();
+				curl_setopt($c, CURLOPT_URL, 'https://www.papaki.gr/cp2/manageDNS/manageDNS.aspx?did=' . $did . '&mode=' . $mode);
+				curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
+				curl_setopt($c, CURLOPT_COOKIEFILE, 'cookieFile.txt');
+				curl_setopt($c, CURLOPT_COOKIEJAR, 'cookieFile.txt');
+				$response = curl_exec($c);
+				curl_close($c);
+				$update_html = new simple_html_dom();
+				$update_html->load($response);
+				$view_state = $update_html->find('input[id=__VIEWSTATE]');
+				$event_validation = $update_html->find('input[id=__EVENTVALIDATION]');
+
+				// Do the post to update form
+				if (DEBUG) print_r("Posting new data.\n");
+				$post_fields = array();
+				$post_fields['__EVENTTARGET'] = 'btn_add';
+				$post_fields['__VIEWSTATE'] = $view_state[0]->value;
+				$post_fields['__EVENTVALIDATION'] = $event_validation[0]->value;
+				$post_fields['txt_Host_A'] = $config['hosts'][$key];
+				$post_fields['txt_IP_A'] = $config['new_ip_address'];
+				$post_fields['lst_ttl_A'] = '3600';
+				$c = curl_init();
+				curl_setopt($c, CURLOPT_URL, 'https://www.papaki.gr/cp2/manageDNS/manageDNS.aspx?did=' . $did . '&mode=' . $mode);
+				curl_setopt($c, CURLOPT_POST, true);
+				curl_setopt($c, CURLOPT_POSTFIELDS, http_build_query($post_fields));
+				curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
+				curl_setopt($c, CURLOPT_COOKIEFILE, 'cookieFile.txt');
+				curl_setopt($c, CURLOPT_COOKIEJAR, 'cookieFile.txt');
+				$response = curl_exec($c);
+				curl_close($c);
+
+				$records_updated++;
 			}
-
-			if (DEBUG) print_r("The record has to be updated.!\n");
-
-			$search_id = 'rpttypes_ctl00_rptRecords_' . $rptRecord . '_lnk_edit';
-			$edit_button = $html->find('a[id=' . $search_id . ']');
-			$did = $edit_button[0]->did;
-			$mode = $edit_button[0]->mode;
-
-			// Fetch update form, so we can get VIEWSTATE and EVENTVALIDATION
-			if (DEBUG) print_r("Fetching update form.\n");
-			$c = curl_init();
-			curl_setopt($c, CURLOPT_URL, 'https://www.papaki.gr/cp2/manageDNS/manageDNS.aspx?did=' . $did . '&mode=' . $mode);
-			curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($c, CURLOPT_COOKIEFILE, 'cookieFile.txt');
-			curl_setopt($c, CURLOPT_COOKIEJAR, 'cookieFile.txt');
-			$response = curl_exec($c);
-			curl_close($c);
-			$update_html = new simple_html_dom();
-			$update_html->load($response);
-			$view_state = $update_html->find('input[id=__VIEWSTATE]');
-			$event_validation = $update_html->find('input[id=__EVENTVALIDATION]');
-
-			// Do the post to update form
-			if (DEBUG) print_r("Posting new data.\n");
-			$post_fields = array();
-			$post_fields['__EVENTTARGET'] = 'btn_add';
-			$post_fields['__VIEWSTATE'] = $view_state[0]->value;
-			$post_fields['__EVENTVALIDATION'] = $event_validation[0]->value;
-			$post_fields['txt_Host_A'] = $config['host'];
-			$post_fields['txt_IP_A'] = $config['new_ip_address'];
-			$post_fields['lst_ttl_A'] = '3600';
-			$c = curl_init();
-			curl_setopt($c, CURLOPT_URL, 'https://www.papaki.gr/cp2/manageDNS/manageDNS.aspx?did=' . $did . '&mode=' . $mode);
-			curl_setopt($c, CURLOPT_POST, true);
-			curl_setopt($c, CURLOPT_POSTFIELDS, http_build_query($post_fields));
-			curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($c, CURLOPT_COOKIEFILE, 'cookieFile.txt');
-			curl_setopt($c, CURLOPT_COOKIEJAR, 'cookieFile.txt');
-			$response = curl_exec($c);
-			curl_close($c);
-
-			$record_updated = TRUE;
 		}
 	}
 }
 
-if ($record_updated == FALSE)
+if (DEBUG) print_r("Updated ".$records_updated." out of " . count($config['full_hosts']) . " records\n");
+
+if ($records_updated < count($config['full_hosts']))
 {
-	// insert new record
-	if (DEBUG) print_r("Record not found. I have to insert a new one but its not implemented yet.\n");
+	//Not all hosts found - maybe need to create entries
+	if (DEBUG) print_r("WARNING: One or more records were not found. We may have to insert new ones but that has not been implemented yet.\n");
 }
 
 if (DEBUG) print_r("I think i thaw a puthyduck.\n");


### PR DESCRIPTION
Since papaki.com still does not support auto-updating IP addresses for our domains I found the tool really useful and extended it to fit my needs, supporting multiple host names per domain.

I have now set it to run through a bash script on Ubuntu Server 16.04 using a simple command "php papakiDynDNS.php", so that saves me the hassle to have to log in and change each entry separately every time the server's (dynamic) IP changes.

You need to update the "Setup" section with your server's details:

//Setup
$config['hosts'] = array('', 'www', 'mail'); //Add all your host names here
$config['domain'] = 'example.gr';
$config['new_ip_address'] = file_get_contents('http://icanhazip.com/'); //Update this with the IP of your server if not on it
$config['papaki_username'] = 'username';
$config['papaki_password'] = 'password';

Then you can save, exit, and run the script on your server through the command line using the following command:
"php papakiDynDNS.php"

It could also be further extended to work based on external parameters.
I hope it makes someone's life easier!